### PR TITLE
Fix error for existing path in user documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Fixed "Path already exists" error that prevented organizing files into existing directories. The validator now correctly allows organizing into existing directories while still preventing conflicts when a file (not a directory) exists with the same name as a suggested folder.
+
+### Changed
 - Initial release setup.

--- a/Sources/SortyLib/Models/WorkspaceHealth.swift
+++ b/Sources/SortyLib/Models/WorkspaceHealth.swift
@@ -1103,10 +1103,10 @@ public class WorkspaceHealthManager: ObservableObject {
                name.hasSuffix("~")
     }
 
-    /// Find empty folders in a directory (non-recursive check for immediate children)
+    /// Find empty folders in a directory, including folders that only contain other empty folders
     private func findEmptyFolders(at path: String) async -> [String] {
         let fileManager = FileManager.default
-        var emptyFolders: [String] = []
+        var allDirectories: [(path: String, depth: Int)] = []
 
         guard let enumerator = fileManager.enumerator(
             at: URL(fileURLWithPath: path),
@@ -1116,23 +1116,59 @@ public class WorkspaceHealthManager: ObservableObject {
             return []
         }
 
+        // First pass: collect all directories with their depth
         while let url = enumerator.nextObject() as? URL {
             do {
                 let resourceValues = try url.resourceValues(forKeys: [.isDirectoryKey])
                 if resourceValues.isDirectory == true {
-                    let contents = try fileManager.contentsOfDirectory(atPath: url.path)
-                    // Filter out hidden files
-                    let visibleContents = contents.filter { !$0.hasPrefix(".") }
-                    if visibleContents.isEmpty {
-                        emptyFolders.append(url.path)
-                    }
+                    let depth = url.path.components(separatedBy: "/").count
+                    allDirectories.append((path: url.path, depth: depth))
                 }
             } catch {
                 continue
             }
         }
 
-        return emptyFolders
+        // Sort by depth (deepest first) to process leaf directories before their parents
+        allDirectories.sort { $0.depth > $1.depth }
+
+        // Second pass: determine which directories are truly empty
+        var emptyFolders = Set<String>()
+        for directory in allDirectories {
+            do {
+                let contents = try fileManager.contentsOfDirectory(atPath: directory.path)
+                // Filter out hidden files
+                let visibleContents = contents.filter { !$0.hasPrefix(".") }
+                
+                // Check if all visible contents are directories that are already marked as empty
+                var allContentsAreEmpty = true
+                for item in visibleContents {
+                    let itemPath = (directory.path as NSString).appendingPathComponent(item)
+                    var isDirectory: ObjCBool = false
+                    if fileManager.fileExists(atPath: itemPath, isDirectory: &isDirectory) {
+                        if isDirectory.boolValue {
+                            // If it's a directory but not in our empty set, then this parent is not empty
+                            if !emptyFolders.contains(itemPath) {
+                                allContentsAreEmpty = false
+                                break
+                            }
+                        } else {
+                            // If it's a file, then this directory is not empty
+                            allContentsAreEmpty = false
+                            break
+                        }
+                    }
+                }
+                
+                if visibleContents.isEmpty || allContentsAreEmpty {
+                    emptyFolders.insert(directory.path)
+                }
+            } catch {
+                continue
+            }
+        }
+
+        return Array(emptyFolders)
     }
 
     /// Find broken symbolic links in a directory

--- a/Sources/SortyLib/Models/WorkspaceHealth.swift
+++ b/Sources/SortyLib/Models/WorkspaceHealth.swift
@@ -200,6 +200,7 @@ public struct CleanupOpportunity: Codable, Identifiable, Sendable {
         case pruneEmptyFolders = "Prune Empty Folders"
         case removeBrokenSymlinks = "Remove Broken Symlinks"
         case organizeRoot = "Organize Root Files"
+        case archiveVeryOldFiles = "Archive Very Old Files"
         
         public var icon: String {
             switch self {
@@ -209,6 +210,7 @@ public struct CleanupOpportunity: Codable, Identifiable, Sendable {
             case .pruneEmptyFolders: return "folder.badge.minus"
             case .removeBrokenSymlinks: return "link.badge.minus"
             case .organizeRoot: return "wand.and.stars"
+            case .archiveVeryOldFiles: return "archivebox.fill"
             }
         }
     }
@@ -625,7 +627,8 @@ public class WorkspaceHealthManager: ObservableObject {
                     description: "\(veryOldFiles.count) files haven't been accessed in over \(years) years. Consider archiving.",
                     estimatedSavings: totalSize,
                     fileCount: veryOldFiles.count,
-                    priority: totalSize > 1_000_000_000 ? .high : .medium
+                    priority: totalSize > 1_000_000_000 ? .high : .medium,
+                    action: .archiveVeryOldFiles
                 ))
             }
         }
@@ -816,6 +819,8 @@ public class WorkspaceHealthManager: ObservableObject {
             // but we could trigger a specific mode here if needed.
             // For now, we'll assume the UI routes this to the main organizer.
             break
+        case .archiveVeryOldFiles:
+            try await archiveVeryOldFiles(at: path)
         }
         
         // Refresh analysis after action
@@ -1062,6 +1067,8 @@ public class WorkspaceHealthManager: ObservableObject {
     
     private func pruneEmptyFoldersRecursively(at path: String) async throws {
         let fileManager = FileManager.default
+        let disposableFiles: Set<String> = [".DS_Store", "Thumbs.db", "desktop.ini", ".localized"]
+        
         // Find all empty folders (already identifies nested empties correctly)
         let emptyFolders = await findEmptyFolders(at: path)
         
@@ -1070,11 +1077,32 @@ public class WorkspaceHealthManager: ObservableObject {
             path1.components(separatedBy: "/").count > path2.components(separatedBy: "/").count
         }
         
+        var successCount = 0
+        var failureCount = 0
+        
         // Remove all empty folders in one pass
-        // Use try? to continue processing even if a folder is already removed or locked
         for folderPath in sortedFolders {
-            try? fileManager.removeItem(atPath: folderPath)
+            do {
+                // First, remove any disposable files inside
+                let contents = try fileManager.contentsOfDirectory(atPath: folderPath)
+                for item in contents {
+                    if disposableFiles.contains(item) {
+                        let itemPath = (folderPath as NSString).appendingPathComponent(item)
+                        try? fileManager.removeItem(atPath: itemPath)
+                    }
+                }
+                
+                // Now try to remove the folder itself
+                try fileManager.removeItem(atPath: folderPath)
+                successCount += 1
+            } catch {
+                // Log the error for debugging but continue processing other folders
+                DebugLogger.log("Failed to remove empty folder at \(folderPath): \(error.localizedDescription)")
+                failureCount += 1
+            }
         }
+        
+        DebugLogger.log("Pruned \(successCount) empty folders, \(failureCount) failures")
     }
     
     private func removeBrokenSymlinks(at path: String) async throws {
@@ -1083,6 +1111,57 @@ public class WorkspaceHealthManager: ObservableObject {
         for linkPath in brokenLinks {
             try fileManager.removeItem(atPath: linkPath)
         }
+    }
+    
+    private func archiveVeryOldFiles(at path: String) async throws {
+        let fileManager = FileManager.default
+        
+        // Get the user's home directory and create Archives folder in Documents
+        let homeDirectory = fileManager.homeDirectoryForCurrentUser
+        let documentsFolder = homeDirectory.appendingPathComponent("Documents")
+        let archiveFolder = documentsFolder.appendingPathComponent("Archives")
+        
+        // Create Archives folder if it doesn't exist
+        if !fileManager.fileExists(atPath: archiveFolder.path) {
+            try fileManager.createDirectory(at: archiveFolder, withIntermediateDirectories: true)
+        }
+        
+        // Get all files in the directory
+        let files = try fileManager.contentsOfDirectory(
+            at: URL(fileURLWithPath: path), 
+            includingPropertiesForKeys: [.contentAccessDateKey, .contentModificationDateKey], 
+            options: [.skipsHiddenFiles]
+        )
+        
+        var movedCount = 0
+        
+        for file in files {
+            guard !file.hasDirectoryPath else { continue }
+            
+            // Check if file is "very old" using the same criteria as analysis
+            let resourceValues = try? file.resourceValues(forKeys: [.contentAccessDateKey, .contentModificationDateKey])
+            let accessDate = resourceValues?.contentAccessDate ?? resourceValues?.contentModificationDate
+            
+            if let lastAccess = accessDate,
+               Date().timeIntervalSince(lastAccess) > config.oldFileThreshold {
+                
+                var destination = archiveFolder.appendingPathComponent(file.lastPathComponent)
+                
+                // Handle filename conflicts by appending a timestamp
+                if fileManager.fileExists(atPath: destination.path) {
+                    let fileName = file.deletingPathExtension().lastPathComponent
+                    let ext = file.pathExtension
+                    let timestamp = Date().filenameTimestamp
+                    let uniqueName = ext.isEmpty ? "\(fileName)_\(timestamp)" : "\(fileName)_\(timestamp).\(ext)"
+                    destination = archiveFolder.appendingPathComponent(uniqueName)
+                }
+                
+                try fileManager.moveItem(at: file, to: destination)
+                movedCount += 1
+            }
+        }
+        
+        DebugLogger.log("Archived \(movedCount) very old files to \(archiveFolder.path)")
     }
 
     private func isScreenshot(_ file: FileItem) -> Bool {
@@ -1108,11 +1187,14 @@ public class WorkspaceHealthManager: ObservableObject {
     private func findEmptyFolders(at path: String) async -> [String] {
         let fileManager = FileManager.default
         var allDirectories: [(path: String, depth: Int)] = []
+        
+        // Disposable files that should be considered as "empty" content
+        let disposableFiles: Set<String> = [".DS_Store", "Thumbs.db", "desktop.ini", ".localized"]
 
         guard let enumerator = fileManager.enumerator(
             at: URL(fileURLWithPath: path),
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
+            options: [] // Don't skip hidden files so we can find all directories
         ) else {
             return []
         }
@@ -1138,12 +1220,13 @@ public class WorkspaceHealthManager: ObservableObject {
         for directory in allDirectories {
             do {
                 let contents = try fileManager.contentsOfDirectory(atPath: directory.path)
-                // Filter out hidden files
-                let visibleContents = contents.filter { !$0.hasPrefix(".") }
                 
-                // Check if all visible contents are directories that are already marked as empty
+                // Filter out disposable files - treat them as if they don't exist
+                let significantContents = contents.filter { !disposableFiles.contains($0) }
+                
+                // Check if all significant contents are directories that are already marked as empty
                 var allContentsAreEmpty = true
-                for item in visibleContents {
+                for item in significantContents {
                     let itemPath = (directory.path as NSString).appendingPathComponent(item)
                     var isDirectory: ObjCBool = false
                     if fileManager.fileExists(atPath: itemPath, isDirectory: &isDirectory) {
@@ -1161,7 +1244,7 @@ public class WorkspaceHealthManager: ObservableObject {
                     }
                 }
                 
-                if visibleContents.isEmpty || allContentsAreEmpty {
+                if significantContents.isEmpty || allContentsAreEmpty {
                     emptyFolders.insert(directory.path)
                 }
             } catch {

--- a/Sources/SortyLib/Models/WorkspaceHealth.swift
+++ b/Sources/SortyLib/Models/WorkspaceHealth.swift
@@ -1152,6 +1152,7 @@ public class WorkspaceHealthManager: ObservableObject {
                     let fileName = file.deletingPathExtension().lastPathComponent
                     let ext = file.pathExtension
                     let timestamp = Date().filenameTimestamp
+                    // Add extension with dot only if file has an extension
                     let uniqueName = ext.isEmpty ? "\(fileName)_\(timestamp)" : "\(fileName)_\(timestamp).\(ext)"
                     destination = archiveFolder.appendingPathComponent(uniqueName)
                 }
@@ -1194,7 +1195,7 @@ public class WorkspaceHealthManager: ObservableObject {
         guard let enumerator = fileManager.enumerator(
             at: URL(fileURLWithPath: path),
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: [] // Don't skip hidden files so we can find all directories
+            options: [] // Don't skip hidden files - we need to check all content to identify truly empty folders
         ) else {
             return []
         }

--- a/Sources/SortyLib/Models/WorkspaceHealth.swift
+++ b/Sources/SortyLib/Models/WorkspaceHealth.swift
@@ -1071,8 +1071,9 @@ public class WorkspaceHealthManager: ObservableObject {
         }
         
         // Remove all empty folders in one pass
+        // Use try? to continue processing even if a folder is already removed or locked
         for folderPath in sortedFolders {
-            try fileManager.removeItem(atPath: folderPath)
+            try? fileManager.removeItem(atPath: folderPath)
         }
     }
     

--- a/Sources/SortyLib/Models/WorkspaceHealth.swift
+++ b/Sources/SortyLib/Models/WorkspaceHealth.swift
@@ -1121,7 +1121,7 @@ public class WorkspaceHealthManager: ObservableObject {
             do {
                 let resourceValues = try url.resourceValues(forKeys: [.isDirectoryKey])
                 if resourceValues.isDirectory == true {
-                    let depth = url.path.components(separatedBy: "/").count
+                    let depth = url.pathComponents.count
                     allDirectories.append((path: url.path, depth: depth))
                 }
             } catch {

--- a/Sources/SortyLib/Models/WorkspaceHealth.swift
+++ b/Sources/SortyLib/Models/WorkspaceHealth.swift
@@ -1062,17 +1062,17 @@ public class WorkspaceHealthManager: ObservableObject {
     
     private func pruneEmptyFoldersRecursively(at path: String) async throws {
         let fileManager = FileManager.default
-        // We need a depth-first traversal to remove nested empty folders
-        // Simple implementation: repeatedly find empty folders and remove them until none found
+        // Find all empty folders (already identifies nested empties correctly)
+        let emptyFolders = await findEmptyFolders(at: path)
         
-        var hasRemoved = true
-        while hasRemoved {
-            hasRemoved = false
-            let emptyFolders = await findEmptyFolders(at: path)
-            for folderPath in emptyFolders {
-                try fileManager.removeItem(atPath: folderPath)
-                hasRemoved = true
-            }
+        // Sort by depth (deepest first) to ensure child folders are removed before parents
+        let sortedFolders = emptyFolders.sorted { path1, path2 in
+            path1.components(separatedBy: "/").count > path2.components(separatedBy: "/").count
+        }
+        
+        // Remove all empty folders in one pass
+        for folderPath in sortedFolders {
+            try fileManager.removeItem(atPath: folderPath)
         }
     }
     

--- a/Sources/SortyLib/Organizer/FileOrganizationValidator.swift
+++ b/Sources/SortyLib/Organizer/FileOrganizationValidator.swift
@@ -40,9 +40,7 @@ struct FileOrganizationValidator {
                 throw ValidationError.pathConflict(folderPath)
             }
             
-            // Allow organizing into existing directories since FileSystemManager
-            // uses createDirectory(withIntermediateDirectories:true) which handles this gracefully
-            // Only check if the path exists and is NOT a directory (i.e., it's a file)
+            // Allow organizing into existing directories - only reject paths that exist as files
             var isDirectory: ObjCBool = false
             if fileManager.fileExists(atPath: folderPath, isDirectory: &isDirectory) {
                 if !isDirectory.boolValue {

--- a/Sources/SortyLib/Organizer/FileOrganizationValidator.swift
+++ b/Sources/SortyLib/Organizer/FileOrganizationValidator.swift
@@ -40,8 +40,16 @@ struct FileOrganizationValidator {
                 throw ValidationError.pathConflict(folderPath)
             }
             
-            if fileManager.fileExists(atPath: folderPath) {
-                throw ValidationError.pathExists(folderPath)
+            // Allow organizing into existing directories since FileSystemManager
+            // uses createDirectory(withIntermediateDirectories:true) which handles this gracefully
+            // Only check if the path exists and is NOT a directory (i.e., it's a file)
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: folderPath, isDirectory: &isDirectory) {
+                if !isDirectory.boolValue {
+                    // Path exists but is a file, not a directory - this is a conflict
+                    throw ValidationError.pathExists(folderPath)
+                }
+                // If it's already a directory, that's fine - we can organize into it
             }
             
             existingPaths.insert(folderPath)

--- a/Tests/SortyTests/FileOrganizerTests.swift
+++ b/Tests/SortyTests/FileOrganizerTests.swift
@@ -197,7 +197,7 @@ class SortyTests: XCTestCase {
     
     @MainActor
     func testRejectOrganizingIntoExistingFile() async throws {
-        // Setup: Create a file and a file (not directory) with the same name as suggested folder
+        // Setup: Create test files including one that will conflict with the suggested folder name
         let dummyFileURL = tempDirectory.appendingPathComponent("test.txt")
         try "content".write(to: dummyFileURL, atomically: true, encoding: .utf8)
         

--- a/Tests/SortyTests/FileOrganizerTests.swift
+++ b/Tests/SortyTests/FileOrganizerTests.swift
@@ -157,4 +157,86 @@ class SortyTests: XCTestCase {
         XCTAssertNil(folderOrganizer.currentPlan)
         XCTAssertEqual(folderOrganizer.progress, 0.0)
     }
+    
+    @MainActor
+    func testOrganizeIntoExistingDirectory() async throws {
+        // Setup: Create a file and an existing directory
+        let dummyFileURL = tempDirectory.appendingPathComponent("test.txt")
+        try "content".write(to: dummyFileURL, atomically: true, encoding: .utf8)
+        
+        let existingDirURL = tempDirectory.appendingPathComponent("ExistingFolder")
+        try FileManager.default.createDirectory(at: existingDirURL, withIntermediateDirectories: true)
+        
+        folderOrganizer.aiClient = mockClient
+        
+        // Setup: Mock returns a plan with a folder name that already exists
+        await mockClient.setHandler { files in
+            return OrganizationPlan(
+                suggestions: [
+                    FolderSuggestion(
+                        folderName: "ExistingFolder",
+                        description: "Test folder",
+                        files: files,
+                        subfolders: [],
+                        reasoning: "Test"
+                    )
+                ],
+                unorganizedFiles: [],
+                notes: "Test Plan"
+            )
+        }
+        
+        // Act: This should NOT throw an error even though ExistingFolder already exists
+        try await folderOrganizer.organize(directory: tempDirectory)
+        
+        // Assert: Organization should succeed
+        XCTAssertEqual(folderOrganizer.state, .ready)
+        XCTAssertNotNil(folderOrganizer.currentPlan)
+        XCTAssertEqual(folderOrganizer.currentPlan?.suggestions.first?.folderName, "ExistingFolder")
+    }
+    
+    @MainActor
+    func testRejectOrganizingIntoExistingFile() async throws {
+        // Setup: Create a file and a file (not directory) with the same name as suggested folder
+        let dummyFileURL = tempDirectory.appendingPathComponent("test.txt")
+        try "content".write(to: dummyFileURL, atomically: true, encoding: .utf8)
+        
+        // Create a file (not directory) with the name we'll suggest as a folder
+        let existingFileURL = tempDirectory.appendingPathComponent("ConflictingFile")
+        try "existing file content".write(to: existingFileURL, atomically: true, encoding: .utf8)
+        
+        folderOrganizer.aiClient = mockClient
+        
+        // Setup: Mock returns a plan with a folder name that conflicts with an existing file
+        await mockClient.setHandler { files in
+            return OrganizationPlan(
+                suggestions: [
+                    FolderSuggestion(
+                        folderName: "ConflictingFile",
+                        description: "Test folder",
+                        files: files,
+                        subfolders: [],
+                        reasoning: "Test"
+                    )
+                ],
+                unorganizedFiles: [],
+                notes: "Test Plan"
+            )
+        }
+        
+        // Act & Assert: This should throw a validation error because ConflictingFile exists as a file
+        do {
+            try await folderOrganizer.organize(directory: tempDirectory)
+            XCTFail("Should have thrown a validation error")
+        } catch let error as ValidationError {
+            // Verify it's the correct error type
+            if case .pathExists(let path) = error {
+                XCTAssertTrue(path.contains("ConflictingFile"))
+            } else {
+                XCTFail("Wrong validation error type: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
 }

--- a/Tests/SortyTests/WorkspaceHealthQuickActionTests.swift
+++ b/Tests/SortyTests/WorkspaceHealthQuickActionTests.swift
@@ -155,4 +155,81 @@ class WorkspaceHealthQuickActionTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: empty2.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: notEmpty.path))
     }
+    
+    @MainActor
+    func testArchiveVeryOldFiles() async throws {
+        // Setup: Create very old files and recent files
+        let oldFile1 = tempDirectory.appendingPathComponent("very_old_document.txt")
+        try "old content".write(to: oldFile1, atomically: true, encoding: .utf8)
+        let veryOldDate = Date().addingTimeInterval(-400 * 86400) // Over 1 year old
+        try FileManager.default.setAttributes([.modificationDate: veryOldDate], ofItemAtPath: oldFile1.path)
+        
+        let oldFile2 = tempDirectory.appendingPathComponent("ancient_file.pdf")
+        try "ancient content".write(to: oldFile2, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: veryOldDate], ofItemAtPath: oldFile2.path)
+        
+        let recentFile = tempDirectory.appendingPathComponent("recent_file.txt")
+        try "recent content".write(to: recentFile, atomically: true, encoding: .utf8)
+        
+        // Act
+        let opportunity = CleanupOpportunity(
+            type: .veryOldFiles,
+            directoryPath: tempDirectory.path,
+            description: "Test",
+            estimatedSavings: 200,
+            fileCount: 2,
+            action: .archiveVeryOldFiles
+        )
+        
+        try await healthManager.performAction(.archiveVeryOldFiles, for: opportunity)
+        
+        // Assert: Very old files moved to ~/Documents/Archives
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+        let documentsFolder = homeDirectory.appendingPathComponent("Documents")
+        let archiveFolder = documentsFolder.appendingPathComponent("Archives")
+        
+        let archivedFile1 = archiveFolder.appendingPathComponent("very_old_document.txt")
+        let archivedFile2 = archiveFolder.appendingPathComponent("ancient_file.pdf")
+        
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archivedFile1.path), "Old file should be archived")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archivedFile2.path), "Old file should be archived")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldFile1.path), "Old file should be moved from source")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldFile2.path), "Old file should be moved from source")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recentFile.path), "Recent file should remain")
+        
+        // Cleanup: Remove created archive files
+        try? FileManager.default.removeItem(at: archivedFile1)
+        try? FileManager.default.removeItem(at: archivedFile2)
+    }
+    
+    @MainActor
+    func testPruneEmptyFoldersWithDSStore() async throws {
+        // Setup: Create folder with only .DS_Store
+        let folderWithDSStore = tempDirectory.appendingPathComponent("FolderWithDSStore")
+        try FileManager.default.createDirectory(at: folderWithDSStore, withIntermediateDirectories: true)
+        
+        let dsStore = folderWithDSStore.appendingPathComponent(".DS_Store")
+        try "ds_store_content".write(to: dsStore, atomically: true, encoding: .utf8)
+        
+        let notEmptyFolder = tempDirectory.appendingPathComponent("NotEmpty")
+        try FileManager.default.createDirectory(at: notEmptyFolder, withIntermediateDirectories: true)
+        let realFile = notEmptyFolder.appendingPathComponent("real_file.txt")
+        try "content".write(to: realFile, atomically: true, encoding: .utf8)
+        
+        // Act
+        let opportunity = CleanupOpportunity(
+            type: .emptyFolders,
+            directoryPath: tempDirectory.path,
+            description: "Test",
+            estimatedSavings: 0,
+            fileCount: 1,
+            action: .pruneEmptyFolders
+        )
+        
+        try await healthManager.performAction(.pruneEmptyFolders, for: opportunity)
+        
+        // Assert: Folder with only .DS_Store should be removed
+        XCTAssertFalse(FileManager.default.fileExists(atPath: folderWithDSStore.path), "Folder with only .DS_Store should be removed")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: notEmptyFolder.path), "Folder with real files should remain")
+    }
 }

--- a/Tests/SortyTests/WorkspaceHealthTests.swift
+++ b/Tests/SortyTests/WorkspaceHealthTests.swift
@@ -793,4 +793,65 @@ class WorkspaceHealthIntegrationTests: XCTestCase {
         XCTAssertTrue(healthManager.insights.first!.isRead)
         XCTAssertTrue(healthManager.unreadInsights.isEmpty)
     }
+    
+    @MainActor
+    func testEmptyFoldersDetection() async throws {
+        let healthManager = WorkspaceHealthManager()
+        
+        // Create a temporary test directory
+        let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        
+        // Test case 1: Simple empty folder
+        let emptyFolder1 = tempDirectory.appendingPathComponent("EmptyFolder1")
+        try FileManager.default.createDirectory(at: emptyFolder1, withIntermediateDirectories: true)
+        
+        // Test case 2: Folder with only empty subfolders (the bug fix target)
+        let parentFolder = tempDirectory.appendingPathComponent("ParentFolder")
+        let emptyChild1 = parentFolder.appendingPathComponent("EmptyChild1")
+        let emptyChild2 = parentFolder.appendingPathComponent("EmptyChild2")
+        try FileManager.default.createDirectory(at: emptyChild1, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: emptyChild2, withIntermediateDirectories: true)
+        
+        // Test case 3: Deeply nested empty folders
+        let deepParent = tempDirectory.appendingPathComponent("DeepParent")
+        let deepChild = deepParent.appendingPathComponent("DeepChild")
+        let deepGrandchild = deepChild.appendingPathComponent("DeepGrandchild")
+        try FileManager.default.createDirectory(at: deepGrandchild, withIntermediateDirectories: true)
+        
+        // Test case 4: Folder with a file (should NOT be detected as empty)
+        let folderWithFile = tempDirectory.appendingPathComponent("FolderWithFile")
+        try FileManager.default.createDirectory(at: folderWithFile, withIntermediateDirectories: true)
+        try "content".write(to: folderWithFile.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        
+        // Test case 5: Folder with only hidden files (should be detected as empty)
+        let folderWithHiddenFile = tempDirectory.appendingPathComponent("FolderWithHiddenFile")
+        try FileManager.default.createDirectory(at: folderWithHiddenFile, withIntermediateDirectories: true)
+        try "content".write(to: folderWithHiddenFile.appendingPathComponent(".DS_Store"), atomically: true, encoding: .utf8)
+        
+        // Analyze the directory
+        await healthManager.analyzeDirectory(path: tempDirectory.path, files: [])
+        
+        // Find the empty folders opportunity
+        let emptyFoldersOpp = healthManager.opportunities.first { $0.type == .emptyFolders }
+        
+        // Verify that the empty folders opportunity was detected
+        XCTAssertNotNil(emptyFoldersOpp, "Empty folders opportunity should be detected")
+        
+        if let opportunity = emptyFoldersOpp {
+            // Verify that all expected empty folders were found
+            // Should find: EmptyFolder1, ParentFolder, EmptyChild1, EmptyChild2, 
+            //              DeepParent, DeepChild, DeepGrandchild, FolderWithHiddenFile
+            // Total: 8 folders
+            XCTAssertGreaterThanOrEqual(opportunity.fileCount, 8, 
+                "Should detect at least 8 empty folders (including parent folders with only empty children)")
+            
+            // Verify description
+            XCTAssertTrue(opportunity.description.contains("empty folders"), 
+                "Description should mention empty folders")
+        }
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Allow organizing into existing directories while still preventing conflicts when a file exists at the target path (fixes "Path already exists" error).

* **Improvement**
  * Better empty-folder detection and pruning: depth-aware, handles nested empties and disposable hidden files.

* **New Features**
  * Quick action to archive very old files into an Archives folder with conflict-safe naming.

* **Tests**
  * Added tests for directory organizing behaviors, empty-folder detection, pruning, and archiving.

* **Documentation**
  * Changelog updated to mark initial release setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->